### PR TITLE
(md:132537) Show parent in selection category subject

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -441,3 +441,17 @@ def replace_solr_schema(core):
         env.schema_remote_path[core]
     )
     run('sudo systemctl restart solr')
+
+
+@task
+def dropdb():
+    """Drop database.
+
+    Drop database without create it again
+
+    Usage:
+        >>>fab environment:vagrant dropdb.
+    """
+    urun('dropdb knowledge_base')
+
+

--- a/src/knowledge_base/posts/admin.py
+++ b/src/knowledge_base/posts/admin.py
@@ -53,18 +53,18 @@ class SubjectAdmin(admin.ModelAdmin):
     )
 
     def _category(self, instance):
-        return instance.category.name
+        return instance.category.name.encode('utf-8')
 
 
     def area(self, instance):
-        return instance.category.area.name
+        return instance.category.area.name.encode('utf-8')
 
 
 class PostAdmin(admin.ModelAdmin):
     list_display = (
         'name',
         '_subject',
-        'category',
+        '_category',
         'area',
         'author',
         'is_active'
@@ -83,13 +83,13 @@ class PostAdmin(admin.ModelAdmin):
     )
 
     def _subject(self, instance):
-        return instance.subject.name
+        return instance.subject.name.encode('utf-8')
 
-    def category(self, instance):
-        return instance.subject.category.name
+    def _category(self, instance):
+        return instance.subject.category.name.encode('utf-8')
 
     def area(self, instance):
-        return instance.subject.category.area.name
+        return instance.subject.category.area.name.encode('utf-8')
 
 
 admin.site.register(Area, AreaAdmin)

--- a/src/knowledge_base/posts/admin.py
+++ b/src/knowledge_base/posts/admin.py
@@ -37,7 +37,7 @@ class SubjectAdmin(admin.ModelAdmin):
     list_display = (
         'name',
         'description',
-        'category',
+        '_category',
         'area',
         'is_active'
     )
@@ -52,6 +52,10 @@ class SubjectAdmin(admin.ModelAdmin):
         'category__area',
     )
 
+    def _category(self, instance):
+        return instance.category.name
+
+
     def area(self, instance):
         return instance.category.area.name
 
@@ -59,7 +63,7 @@ class SubjectAdmin(admin.ModelAdmin):
 class PostAdmin(admin.ModelAdmin):
     list_display = (
         'name',
-        'subject',
+        '_subject',
         'category',
         'area',
         'author',
@@ -77,6 +81,9 @@ class PostAdmin(admin.ModelAdmin):
         'subject',
         'name',
     )
+
+    def _subject(self, instance):
+        return instance.subject.name
 
     def category(self, instance):
         return instance.subject.category.name

--- a/src/knowledge_base/posts/models.py
+++ b/src/knowledge_base/posts/models.py
@@ -81,6 +81,13 @@ class Category(CatalogueMixin):
         verbose_name = 'category'
         verbose_name_plural = 'categories'
 
+    def __unicode__(self):
+        return self.get_full_name()
+
+    def get_full_name(self):
+        area = Area.objects.get(id=self.area_id)
+        return u"%s > %s" % (area.name, self.name)
+
 
 class Subject(CatalogueMixin):
     """
@@ -96,6 +103,13 @@ class Subject(CatalogueMixin):
         null=True,
         blank=True
     )
+
+    def __unicode__(self):
+        return self.get_full_name()
+
+    def get_full_name(self):
+        category = Category.objects.get(id=self.category_id)
+        return u"%s > %s" % (category.name, self.name)
 
 
 class Post(CatalogueMixin):

--- a/src/knowledge_base/posts/models.py
+++ b/src/knowledge_base/posts/models.py
@@ -86,7 +86,7 @@ class Category(CatalogueMixin):
 
     def get_full_name(self):
         area = Area.objects.get(id=self.area_id)
-        return u"%s > %s" % (area.name, self.name)
+        return u"{0} > {1}".format(area.name, self.name)
 
 
 class Subject(CatalogueMixin):
@@ -109,7 +109,7 @@ class Subject(CatalogueMixin):
 
     def get_full_name(self):
         category = Category.objects.get(id=self.category_id)
-        return u"%s > %s" % (category.name, self.name)
+        return u"{0} > {1}".format(category.name, self.name)
 
 
 class Post(CatalogueMixin):


### PR DESCRIPTION
# Tareas relacionadas

[[Pensadero] mostrar mas detallado el selector de category en subject y subject en post ](http://manoderecha.net/md/index.php/task/132537)

# Descripción del problema

En el panel de administracion, en el momento de editar o agregar un "category" o un "subject" no se puede identificar quien es el padre de tal selector

# Descripción de la solución

Se agrego la función __unicode__ al modelo "subject" y "category", y se ajusta la manera de ver en el panel de administración

# Plan de pruebas

![captura de pantalla de 2017-06-08 16-51-51](https://user-images.githubusercontent.com/8001936/26952368-cf162be0-4c6a-11e7-8801-0c029ff24f48.png)
![captura de pantalla de 2017-06-08 16-51-19](https://user-images.githubusercontent.com/8001936/26952367-cf160c28-4c6a-11e7-902f-87e4b9cc6ea1.png)
